### PR TITLE
Fixed duplicate remove call to S3

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -45,18 +45,6 @@ module.exports = {
               return resolve();
             }
           );
-          S3.deleteObject(
-            {
-              Key: `webp/${path}${file.hash}.webp`,
-              ...customParams,
-            },
-            (err) => {
-              if (err) {
-                return reject(err);
-              }
-              return resolve();
-            }
-          );
         });
       },
     };


### PR DESCRIPTION
Hi,

I have removed duplicated s3 call to removing the file. 

If you look above the deleted lines, you will see, that the path is created before and this delete is deleting only `webp`.



